### PR TITLE
Fixed #142 and updated from javalin4 to javalin5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## \[5.5.0] - 2022-11-20
+### Added
+- Jexxa-Core: Provide possibility to configure user.timezone via jexxa-application.properties value `io.jexxa.user.timezone`. See [here](https://github.com/jexxa-projects/Jexxa/blob/master/jexxa-web/src/test/resources/jexxa-application.properties) for more information
+
+### Changed
+- [Issue #142](https://github.com/jexxa-projects/Jexxa/issues/140) Jexxa-Web : Updated from javalin4 to javalin5. This required to reimplement OpenAPI functionality because javalin5 no longer supports a Java-DSL to provide OpenAPI information. Even though the public API of Jexxa-Web is not changed we decided to increment minor version due to the re-implementation of OpenAPI 
+
+### Fixed
+- Updated dependencies
+
+
 ## \[5.4.0] - 2022-11-05
 ### Added
 - Jexxa-Core: Added new driving adapter `Scheduler` which allows to call methods on a fixed rate or fixed delay as described in [issue #140](https://github.com/jexxa-projects/Jexxa/issues/140). See [here](https://github.com/jexxa-projects/Jexxa/blob/master/jexxa-web/src/test/resources/jexxa-application.properties) for more some examples hwo to use it. 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Maven:
     <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-simple</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.4</version>
     </dependency>
 </dependencies>
 ```
@@ -93,7 +93,7 @@ Gradle:
 
 ```groovy
 compile "io.jexxa:jexxa-web:5.4.0"
-compile "org.slf4j:slf4j-simple:2.0.2"
+compile "org.slf4j:slf4j-simple:2.0.4"
 ``` 
 
 ### Configure your Jexxa application  

--- a/jexxa-adapter-api/pom.xml
+++ b/jexxa-adapter-api/pom.xml
@@ -4,11 +4,11 @@
     <parent>
     <artifactId>jexxa</artifactId>
     <groupId>io.jexxa</groupId>
-    <version>5.4.1-SNAPSHOT</version>
+    <version>5.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jexxa-adapter-api</artifactId>
-  <version>3.4.1-SNAPSHOT</version>
+  <version>3.5.0-SNAPSHOT</version>
 
   <name>Jexxa-Adapter-API</name>
 

--- a/jexxa-core/pom.xml
+++ b/jexxa-core/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>jexxa</artifactId>
     <groupId>io.jexxa</groupId>
-    <version>5.4.1-SNAPSHOT</version>
+    <version>5.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jexxa-core</artifactId>
-  <version>5.4.1-SNAPSHOT</version>
+  <version>5.5.0-SNAPSHOT</version>
 
   <name>Jexxa-Core</name>
   <licenses>
@@ -21,7 +21,7 @@
   </licenses>
 
   <properties>
-    <jexxa.adapter.api.version>3.4.1-SNAPSHOT</jexxa.adapter.api.version>
+    <jexxa.adapter.api.version>3.5.0-SNAPSHOT</jexxa.adapter.api.version>
     <sonar.projectKey>repplix_Jexxa</sonar.projectKey>
   </properties>
 

--- a/jexxa-core/src/main/java/io/jexxa/core/JexxaMain.java
+++ b/jexxa-core/src/main/java/io/jexxa/core/JexxaMain.java
@@ -12,7 +12,6 @@ import io.jexxa.utils.annotations.CheckReturnValue;
 import io.jexxa.utils.function.ThrowingConsumer;
 import io.jexxa.utils.properties.JexxaCoreProperties;
 import io.jexxa.utils.properties.PropertiesLoader;
-import org.slf4j.Logger;
 
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
@@ -47,8 +46,6 @@ public final class JexxaMain
     private static final String DOMAIN_PROCESS_SERVICE = ".domainprocessservice";
     private static final String DOMAIN_WORKFLOW = ".domainworkflow";
     private static final String APPLICATION_SERVICE = ".applicationservice";
-
-    private static final Logger LOGGER = JexxaLogger.getLogger(JexxaMain.class);
 
     private final CompositeDrivingAdapter compositeDrivingAdapter = new CompositeDrivingAdapter();
     private final Properties properties;
@@ -304,7 +301,7 @@ public final class JexxaMain
     {
         if ( boundedContext.isRunning() )
         {
-            LOGGER.warn("BoundedContext '{}' already started", getBoundedContext().contextName());
+            JexxaLogger.getLogger(JexxaMain.class).warn("BoundedContext '{}' already started", getBoundedContext().contextName());
             return this;
         }
 
@@ -335,7 +332,7 @@ public final class JexxaMain
     void printStartupDuration()
     {
         var startTime = getBoundedContext().uptime();
-        LOGGER.info("BoundedContext '{}' successfully started in {}.{} seconds", getBoundedContext().contextName(), startTime.toSeconds(), String.format("%03d", startTime.toMillisPart()));
+        JexxaLogger.getLogger(JexxaMain.class).info("BoundedContext '{}' successfully started in {}.{} seconds", getBoundedContext().contextName(), startTime.toSeconds(), String.format("%03d", startTime.toMillisPart()));
     }
 
     @SuppressWarnings("java:S2629")
@@ -345,7 +342,7 @@ public final class JexxaMain
         {
             boundedContext.stop();
             compositeDrivingAdapter.stop();
-            LOGGER.info("BoundedContext '{}' successfully stopped", getBoundedContext().contextName());
+            JexxaLogger.getLogger(JexxaMain.class).info("BoundedContext '{}' successfully stopped", getBoundedContext().contextName());
         }
         executorService.shutdown();
     }
@@ -529,7 +526,7 @@ public final class JexxaMain
                 JexxaBanner.show(jexxaMain.getProperties());
             }
 
-            LOGGER.error("Could not startup Jexxa! {}", errorMessage);
+            JexxaLogger.getLogger(JexxaMain.class).error("Could not startup Jexxa! {}", errorMessage);
 
             jexxaMain.stop();
         }

--- a/jexxa-core/src/main/java/io/jexxa/utils/properties/JexxaCoreProperties.java
+++ b/jexxa-core/src/main/java/io/jexxa/utils/properties/JexxaCoreProperties.java
@@ -17,8 +17,12 @@ public final class JexxaCoreProperties
     /** Defines the build timestamp of the context. This is typically set via maven */
     public static final String JEXXA_CONTEXT_BUILD_TIMESTAMP = "io.jexxa.context.build.timestamp";
 
+    /** Configures the global system property user.timezone to define the timezone used by the application */
+    public static final String JEXXA_USER_TIMEZONE = "io.jexxa.user.timezone";
+
     /** Defines the default properties file which is /jexxa-application.properties */
     public static final String JEXXA_APPLICATION_PROPERTIES = "/jexxa-application.properties";
+
     private JexxaCoreProperties()
     {
         //Private constructor

--- a/jexxa-core/src/main/java/io/jexxa/utils/properties/JexxaCoreProperties.java
+++ b/jexxa-core/src/main/java/io/jexxa/utils/properties/JexxaCoreProperties.java
@@ -2,11 +2,22 @@ package io.jexxa.utils.properties;
 
 public final class JexxaCoreProperties
 {
+    /** Define an additional import file that is loaded. Default value is empty.  */
     public static final String JEXXA_CONFIG_IMPORT =  "io.jexxa.config.import";
+
+    /** Define the name of the bounded context. Default value is the name of the main class of an application   */
     public static final String JEXXA_CONTEXT_NAME =  "io.jexxa.context.name";
+
+    /** Defines the version number of the context. This is typically set via maven */
     public static final String JEXXA_CONTEXT_VERSION = "io.jexxa.context.version";
+
+    /** Defines the repository of the context. This is typically set via maven */
     public static final String JEXXA_CONTEXT_REPOSITORY = "io.jexxa.context.repository";
+
+    /** Defines the build timestamp of the context. This is typically set via maven */
     public static final String JEXXA_CONTEXT_BUILD_TIMESTAMP = "io.jexxa.context.build.timestamp";
+
+    /** Defines the default properties file which is /jexxa-application.properties */
     public static final String JEXXA_APPLICATION_PROPERTIES = "/jexxa-application.properties";
     private JexxaCoreProperties()
     {

--- a/jexxa-core/src/main/java/io/jexxa/utils/properties/PropertiesLoader.java
+++ b/jexxa-core/src/main/java/io/jexxa/utils/properties/PropertiesLoader.java
@@ -15,6 +15,7 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 import static io.jexxa.utils.properties.JexxaCoreProperties.JEXXA_APPLICATION_PROPERTIES;
+import static io.jexxa.utils.properties.JexxaCoreProperties.JEXXA_USER_TIMEZONE;
 
 public class PropertiesLoader {
     private final Class<?> context;
@@ -44,7 +45,17 @@ public class PropertiesLoader {
             importProperties(this.properties.getProperty(JexxaCoreProperties.JEXXA_CONFIG_IMPORT));
         }
 
+        //5. set system properties
+        setSystemProperites(properties);
+
         return removeEmptyValues(properties);
+    }
+
+    private void setSystemProperites(Properties properties) {
+        if (properties.containsKey(JEXXA_USER_TIMEZONE))
+        {
+            System.getProperties().setProperty("user.timezone", properties.getProperty(JEXXA_USER_TIMEZONE));
+        }
     }
 
     public List<String> getPropertiesFiles() {

--- a/jexxa-core/src/main/java/io/jexxa/utils/properties/PropertiesLoader.java
+++ b/jexxa-core/src/main/java/io/jexxa/utils/properties/PropertiesLoader.java
@@ -46,12 +46,12 @@ public class PropertiesLoader {
         }
 
         //5. set system properties
-        setSystemProperites(properties);
+        setSystemProperties(properties);
 
         return removeEmptyValues(properties);
     }
 
-    private void setSystemProperites(Properties properties) {
+    private void setSystemProperties(Properties properties) {
         if (properties.containsKey(JEXXA_USER_TIMEZONE))
         {
             System.getProperties().setProperty("user.timezone", properties.getProperty(JEXXA_USER_TIMEZONE));

--- a/jexxa-core/src/main/java/io/jexxa/utils/properties/PropertiesLoader.java
+++ b/jexxa-core/src/main/java/io/jexxa/utils/properties/PropertiesLoader.java
@@ -61,7 +61,6 @@ public class PropertiesLoader {
         propertiesFiles.add(JEXXA_APPLICATION_PROPERTIES);
     }
 
-
     private Properties removeEmptyValues(Properties properties) {
         var filteredMap = properties.entrySet()
                 .stream()
@@ -78,6 +77,7 @@ public class PropertiesLoader {
         try (InputStream resourceStream = PropertiesLoader.class.getResourceAsStream(resource)) {
             if (resourceStream != null) {
                 properties.load(resourceStream);
+                propertiesFiles.add(resource);
             } else {
                 throw new FileNotFoundException(resource);
             }
@@ -85,11 +85,11 @@ public class PropertiesLoader {
             //2. try to import properties from outside the jar
             try (FileInputStream file = new FileInputStream(resource)) {
                 properties.load(file);
+                propertiesFiles.add(resource);
             } catch (IOException f) {
                 throw new IllegalArgumentException("Properties file " + resource + " not available. Please check the filename!", f);
             }
         }
-        propertiesFiles.add(resource);
     }
 
 }

--- a/jexxa-core/src/test/resources/jexxa-application.properties
+++ b/jexxa-core/src/test/resources/jexxa-application.properties
@@ -1,6 +1,11 @@
 #suppress inspection "UnusedProperty" for whole file
 
 ##########################################
+# Adjust system properties               #
+##########################################
+io.jexxa.user.timezone="UTC"
+
+##########################################
 #Settings for JMSAdapter and JMSSender   #
 ##########################################
 #java.naming.factory.initial=org.apache.activemq.jndi.ActiveMQInitialContextFactory

--- a/jexxa-core/src/test/resources/jexxa-application.properties
+++ b/jexxa-core/src/test/resources/jexxa-application.properties
@@ -3,7 +3,7 @@
 ##########################################
 # Adjust system properties               #
 ##########################################
-io.jexxa.user.timezone="UTC"
+#io.jexxa.user.timezone=UTC
 
 ##########################################
 #Settings for JMSAdapter and JMSSender   #

--- a/jexxa-core/src/test/resources/simplelogger.properties
+++ b/jexxa-core/src/test/resources/simplelogger.properties
@@ -1,0 +1,35 @@
+# SLF4J's SimpleLogger configuration file
+# Simple implementation of Logger that sends all enabled log messages, for all defined loggers, to System.err.
+# Default logging detail level for all instances of SimpleLogger.
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, defaults to "info".
+org.slf4j.simpleLogger.defaultLogLevel=info
+
+# Logging detail level for a SimpleLogger instance named "xxxxx".
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, the default logging detail level is used.
+#org.slf4j.simpleLogger.log.xxxxx=
+org.slf4j.simpleLogger.log.org.eclipse.jetty.server=warn
+org.slf4j.simpleLogger.log.io.javalin=warn
+
+# Set to true if you want the current date and time to be included in output messages.
+# Default is false, and will output the number of milliseconds elapsed since startup.
+org.slf4j.simpleLogger.showDateTime=true
+
+# The date and time format to be used in the output messages.
+# The pattern describing the date and time format is the same that is used in java.text.SimpleDateFormat.
+# If the format is not specified or is invalid, the default format is used.
+# The default format is yyyy-MM-dd HH:mm:ss:SSS Z.
+org.slf4j.simpleLogger.dateTimeFormat='['yyyy-MM-dd'T'HH:mmXXX']' 
+
+# Set to true if you want to output the current thread name.
+# Defaults to true.
+org.slf4j.simpleLogger.showThreadName=false
+
+# Set to true if you want the Logger instance name to be included in output messages.
+# Defaults to true.
+#org.slf4j.simpleLogger.showLogName=true
+
+# Set to true if you want the Logger instance short name to be included in output messages.
+# Defaults to false.
+org.slf4j.simpleLogger.showShortLogName=true

--- a/jexxa-core/src/test/resources/simplelogger.properties
+++ b/jexxa-core/src/test/resources/simplelogger.properties
@@ -1,3 +1,5 @@
+#suppress inspection "UnusedProperty" for whole file
+
 # SLF4J's SimpleLogger configuration file
 # Simple implementation of Logger that sends all enabled log messages, for all defined loggers, to System.err.
 # Default logging detail level for all instances of SimpleLogger.
@@ -20,7 +22,7 @@ org.slf4j.simpleLogger.showDateTime=true
 # The pattern describing the date and time format is the same that is used in java.text.SimpleDateFormat.
 # If the format is not specified or is invalid, the default format is used.
 # The default format is yyyy-MM-dd HH:mm:ss:SSS Z.
-org.slf4j.simpleLogger.dateTimeFormat='['yyyy-MM-dd'T'HH:mmXXX']' 
+org.slf4j.simpleLogger.dateTimeFormat='['yyyy-MM-dd'T'HH:mmXXX']'
 
 # Set to true if you want to output the current thread name.
 # Defaults to true.

--- a/jexxa-test/pom.xml
+++ b/jexxa-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>jexxa</artifactId>
         <groupId>io.jexxa</groupId>
-        <version>5.4.1-SNAPSHOT</version>
+        <version>5.5.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jexxa-test/src/test/resources/simplelogger.properties
+++ b/jexxa-test/src/test/resources/simplelogger.properties
@@ -1,0 +1,35 @@
+# SLF4J's SimpleLogger configuration file
+# Simple implementation of Logger that sends all enabled log messages, for all defined loggers, to System.err.
+# Default logging detail level for all instances of SimpleLogger.
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, defaults to "info".
+org.slf4j.simpleLogger.defaultLogLevel=info
+
+# Logging detail level for a SimpleLogger instance named "xxxxx".
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, the default logging detail level is used.
+#org.slf4j.simpleLogger.log.xxxxx=
+org.slf4j.simpleLogger.log.org.eclipse.jetty.server=warn
+org.slf4j.simpleLogger.log.io.javalin=warn
+
+# Set to true if you want the current date and time to be included in output messages.
+# Default is false, and will output the number of milliseconds elapsed since startup.
+org.slf4j.simpleLogger.showDateTime=true
+
+# The date and time format to be used in the output messages.
+# The pattern describing the date and time format is the same that is used in java.text.SimpleDateFormat.
+# If the format is not specified or is invalid, the default format is used.
+# The default format is yyyy-MM-dd HH:mm:ss:SSS Z.
+org.slf4j.simpleLogger.dateTimeFormat='['yyyy-MM-dd'T'HH:mmXXX']' 
+
+# Set to true if you want to output the current thread name.
+# Defaults to true.
+org.slf4j.simpleLogger.showThreadName=false
+
+# Set to true if you want the Logger instance name to be included in output messages.
+# Defaults to true.
+#org.slf4j.simpleLogger.showLogName=true
+
+# Set to true if you want the Logger instance short name to be included in output messages.
+# Defaults to false.
+org.slf4j.simpleLogger.showShortLogName=true

--- a/jexxa-test/src/test/resources/simplelogger.properties
+++ b/jexxa-test/src/test/resources/simplelogger.properties
@@ -1,3 +1,5 @@
+#suppress inspection "UnusedProperty" for whole file
+
 # SLF4J's SimpleLogger configuration file
 # Simple implementation of Logger that sends all enabled log messages, for all defined loggers, to System.err.
 # Default logging detail level for all instances of SimpleLogger.
@@ -20,7 +22,7 @@ org.slf4j.simpleLogger.showDateTime=true
 # The pattern describing the date and time format is the same that is used in java.text.SimpleDateFormat.
 # If the format is not specified or is invalid, the default format is used.
 # The default format is yyyy-MM-dd HH:mm:ss:SSS Z.
-org.slf4j.simpleLogger.dateTimeFormat='['yyyy-MM-dd'T'HH:mmXXX']' 
+org.slf4j.simpleLogger.dateTimeFormat='['yyyy-MM-dd'T'HH:mmXXX']'
 
 # Set to true if you want to output the current thread name.
 # Defaults to true.

--- a/jexxa-web/pom.xml
+++ b/jexxa-web/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>jexxa</artifactId>
     <groupId>io.jexxa</groupId>
-    <version>5.4.1-SNAPSHOT</version>
+    <version>5.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jexxa-web</artifactId>
-  <version>5.4.1-SNAPSHOT</version>
+  <version>5.5.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>

--- a/jexxa-web/pom.xml
+++ b/jexxa-web/pom.xml
@@ -47,43 +47,42 @@
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-open-api-core</artifactId>
       <version>3.0.1</version>
+      <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.dataformat</groupId>
+          <artifactId>jackson-dataformat-yaml</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+    </exclusions>
     </dependency>
+
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <version>${jackson.core.version}</version>
     </dependency>
+
     <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
       <version>${jackson.core.version}</version>
     </dependency>
+
     <dependency>
-      <groupId>org.scala-lang</groupId>
-      <artifactId>scala-library</artifactId>
-      <version>2.13.10</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.kjetland</groupId>
-      <artifactId>mbknor-jackson-jsonschema_2.13</artifactId>
-      <version>${jackson.jsonschema.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jetbrains.kotlin</groupId>
-          <artifactId>kotlin-scripting-jvm</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.scala-lang</groupId>
-          <artifactId>scala-library</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jdk8</artifactId>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
       <version>${jackson.core.version}</version>
     </dependency>
+
+
     <!-- dependencies for tests -->
     <dependency>
       <groupId>org.junit.platform</groupId>

--- a/jexxa-web/pom.xml
+++ b/jexxa-web/pom.xml
@@ -41,62 +41,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>io.javalin</groupId>
-      <artifactId>javalin-openapi</artifactId>
-      <version>${javalin.version}</version>
-      <!-- Exclude dependencies with security issues -->
-      <exclusions>
-        <exclusion>
-          <groupId>org.yaml</groupId>
-          <artifactId>snakeyaml</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-io</groupId>
-          <artifactId>commons-io</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-codec</groupId>
-          <artifactId>commons-codec</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.json</groupId>
-          <artifactId>json</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.webjars.npm</groupId>
-          <artifactId>jsonpointer</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.webjars.npm</groupId>
-          <artifactId>ansi-regex</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.webjars.npm</groupId>
-          <artifactId>y18n</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.mozilla</groupId>
-          <artifactId>rhino</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.jetbrains.kotlin</groupId>
-          <artifactId>kotlin-stdlib</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.kjetland</groupId>
-          <artifactId>mbknor-jackson-jsonschema_2.13</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <version>${jackson.core.version}</version>

--- a/jexxa-web/pom.xml
+++ b/jexxa-web/pom.xml
@@ -43,6 +43,13 @@
     </dependency>
 
     <dependency>
+      <groupId>io.javalin.community.openapi</groupId>
+      <artifactId>javalin-openapi-plugin</artifactId>
+      <version>${javalin.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-open-api-core</artifactId>
       <version>3.0.1</version>

--- a/jexxa-web/pom.xml
+++ b/jexxa-web/pom.xml
@@ -33,12 +33,19 @@
       <artifactId>gson</artifactId>
       <version>${gson.version}</version>
     </dependency>
+
     <!-- dependencies for RESTulRPCAdapter -->
     <dependency>
       <groupId>io.javalin</groupId>
       <artifactId>javalin</artifactId>
       <version>${javalin.version}</version>
       <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-open-api-core</artifactId>
+      <version>3.0.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/jexxa-web/pom.xml
+++ b/jexxa-web/pom.xml
@@ -42,12 +42,6 @@
       <scope>compile</scope>
     </dependency>
 
-    <dependency>
-      <groupId>io.javalin.community.openapi</groupId>
-      <artifactId>javalin-openapi-plugin</artifactId>
-      <version>${javalin.version}</version>
-      <scope>compile</scope>
-    </dependency>
 
     <dependency>
       <groupId>io.smallrye</groupId>

--- a/jexxa-web/src/main/java/io/jexxa/infrastructure/drivingadapter/rest/RESTfulRPCAdapter.java
+++ b/jexxa-web/src/main/java/io/jexxa/infrastructure/drivingadapter/rest/RESTfulRPCAdapter.java
@@ -51,7 +51,7 @@ public final class RESTfulRPCAdapter implements IDrivingAdapter
     private Server server;
     private ServerConnector sslConnector;
     private ServerConnector httpConnector;
-    private OpenAPIConvention openAPIConvention;
+    private final OpenAPIConvention openAPIConvention = new OpenAPIConvention();
 
     private static final Map<Properties, RESTfulRPCAdapter> RPC_ADAPTER_MAP = new HashMap<>();
 
@@ -102,6 +102,7 @@ public final class RESTfulRPCAdapter implements IDrivingAdapter
     {
         try
         {
+            openAPIConvention.showInfo();
             javalin.start();
         } catch (RuntimeException e)
         {
@@ -283,7 +284,7 @@ public final class RESTfulRPCAdapter implements IDrivingAdapter
                 )
         );
 
-        // TODO: getCommands.forEach( method -> openAPIConvention.documentGET(method.method(), method.resourcePath()));
+        getCommands.forEach( method -> openAPIConvention.documentGET(method.method(), method.resourcePath()));
     }
 
     private void registerPOSTMethods(Object object)
@@ -297,7 +298,7 @@ public final class RESTfulRPCAdapter implements IDrivingAdapter
                 )
         );
 
-        // TODO: postCommands.forEach( method -> openAPIConvention.documentPOST(method.method(), method.resourcePath()));
+        postCommands.forEach( method -> openAPIConvention.documentPOST(method.method(), method.resourcePath()));
     }
 
 

--- a/jexxa-web/src/main/java/io/jexxa/infrastructure/drivingadapter/rest/RESTfulRPCAdapter.java
+++ b/jexxa-web/src/main/java/io/jexxa/infrastructure/drivingadapter/rest/RESTfulRPCAdapter.java
@@ -386,7 +386,7 @@ public final class RESTfulRPCAdapter implements IDrivingAdapter
         var openAPIPath = properties.getProperty(JEXXA_REST_OPEN_API_PATH);
         if (openAPIPath != null && !openAPIPath.isEmpty()) {
             openAPIConvention = new OpenAPIConvention(properties);
-            javalin.get(openAPIPath, httpCtx -> httpCtx.result(openAPIConvention.getInfo()));
+            javalin.get(openAPIPath, httpCtx -> httpCtx.result(openAPIConvention.getOpenAPI()));
         }
 
     }

--- a/jexxa-web/src/main/java/io/jexxa/infrastructure/drivingadapter/rest/openapi/OpenAPIConvention.java
+++ b/jexxa-web/src/main/java/io/jexxa/infrastructure/drivingadapter/rest/openapi/OpenAPIConvention.java
@@ -7,7 +7,12 @@ import org.eclipse.microprofile.openapi.models.OpenAPI;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.Properties;
 
+import static io.jexxa.infrastructure.drivingadapter.rest.JexxaWebProperties.JEXXA_REST_OPEN_API_PATH;
+import static io.jexxa.utils.properties.JexxaCoreProperties.JEXXA_CONTEXT_NAME;
+import static io.jexxa.utils.properties.JexxaCoreProperties.JEXXA_CONTEXT_VERSION;
 import static org.eclipse.microprofile.openapi.OASFactory.createAPIResponse;
 import static org.eclipse.microprofile.openapi.OASFactory.createAPIResponses;
 import static org.eclipse.microprofile.openapi.OASFactory.createInfo;
@@ -15,25 +20,24 @@ import static org.eclipse.microprofile.openapi.OASFactory.createOpenAPI;
 import static org.eclipse.microprofile.openapi.OASFactory.createOperation;
 import static org.eclipse.microprofile.openapi.OASFactory.createPathItem;
 import static org.eclipse.microprofile.openapi.OASFactory.createPaths;
-import static org.eclipse.microprofile.openapi.OASFactory.createServer;
 
 @SuppressWarnings("java:S1602") // required to avoid ambiguous warnings
 public class OpenAPIConvention
 {
     private final OpenAPI openAPI;
+    private final Properties properties;
 
-    public OpenAPIConvention()
+    public OpenAPIConvention(Properties properties)
     {
+        this.properties = properties;
+
         openAPI = createOpenAPI()
                 .openapi("3.0.1")
                 .info(
                         createInfo()
-                                .title("Ping Specification")
-                                .version("1.0")
-                )
-                .addServer(
-                        createServer()
-                                .url("http://localhost:8080/")
+                                .title(properties.getProperty(JEXXA_CONTEXT_NAME, "Unknown Context"))
+                                .description("Auto generated OpenAPI for " + properties.getProperty(JEXXA_CONTEXT_NAME, "Unknown Context"))
+                                .version(properties.getProperty(JEXXA_CONTEXT_VERSION, "1.0"))
                 )
                 .paths(
                         createPaths()
@@ -74,16 +78,18 @@ public class OpenAPIConvention
 
     }
 
-    public void showInfo() {
-        String content;
+    public String getInfo() {
         try {
-            content = OpenApiSerializer.serialize(openAPI, Format.YAML);
+            return OpenApiSerializer.serialize(openAPI, Format.JSON);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        System.out.println(content);
     }
 
+    public Optional<String> getPath()
+    {
+        return Optional.of("/" + properties.getProperty(JEXXA_REST_OPEN_API_PATH));
+    }
 
 
   /*  private static final String APPLICATION_TYPE_JSON = "application/json";

--- a/jexxa-web/src/main/java/io/jexxa/infrastructure/drivingadapter/rest/openapi/OpenAPIConvention.java
+++ b/jexxa-web/src/main/java/io/jexxa/infrastructure/drivingadapter/rest/openapi/OpenAPIConvention.java
@@ -1,61 +1,10 @@
 package io.jexxa.infrastructure.drivingadapter.rest.openapi;
 
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.util.StdDateFormat;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.google.gson.JsonParser;
-import com.kjetland.jackson.jsonSchema.JsonSchemaGenerator;
-import io.javalin.core.JavalinConfig;
-import io.javalin.plugin.openapi.OpenApiOptions;
-import io.javalin.plugin.openapi.OpenApiPlugin;
-import io.javalin.plugin.openapi.annotations.HttpMethod;
-import io.javalin.plugin.openapi.dsl.DocumentedContent;
-import io.javalin.plugin.openapi.dsl.OpenApiBuilder;
-import io.javalin.plugin.openapi.dsl.OpenApiDocumentation;
-import io.javalin.plugin.openapi.utils.OpenApiVersionUtil;
-import io.jexxa.utils.JexxaLogger;
-import io.jexxa.utils.json.JSONManager;
-import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.media.ArraySchema;
-import io.swagger.v3.oas.models.media.BooleanSchema;
-import io.swagger.v3.oas.models.media.ComposedSchema;
-import io.swagger.v3.oas.models.media.IntegerSchema;
-import io.swagger.v3.oas.models.media.NumberSchema;
-import io.swagger.v3.oas.models.media.ObjectSchema;
-import io.swagger.v3.oas.models.media.Schema;
-import io.swagger.v3.oas.models.media.StringSchema;
-
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import java.util.Properties;
-
-import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_ENUMS_USING_TO_STRING;
-import static io.jexxa.infrastructure.drivingadapter.rest.JexxaWebProperties.JEXXA_REST_OPEN_API_PATH;
-import static io.jexxa.utils.properties.JexxaCoreProperties.JEXXA_CONTEXT_NAME;
-import static io.jexxa.utils.properties.JexxaCoreProperties.JEXXA_CONTEXT_VERSION;
-import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
-
 @SuppressWarnings("java:S1602") // required to avoid ambiguous warnings
 public class OpenAPIConvention
 {
-    private static final String APPLICATION_TYPE_JSON = "application/json";
+  /*  private static final String APPLICATION_TYPE_JSON = "application/json";
     private static final String JSON_OBJECT_TYPE = "object";
     private static final String JSON_ARRAY_TYPE = "array";
 
@@ -412,5 +361,5 @@ public class OpenAPIConvention
         {
             //private constructor
         }
-    }
+    }*/
 }

--- a/jexxa-web/src/main/java/io/jexxa/infrastructure/drivingadapter/rest/openapi/OpenAPIConvention.java
+++ b/jexxa-web/src/main/java/io/jexxa/infrastructure/drivingadapter/rest/openapi/OpenAPIConvention.java
@@ -113,25 +113,27 @@ public class OpenAPIConvention
 
     private APIResponse documentReturnType(Method method)
     {
+        if (method.getReturnType().equals(void.class))
+        {
+            return createAPIResponse().description("OK");
+        }
+
+        var mediaType = createMediaType()
+                .schema(createInternalSchema(method.getReturnType(), method.getGenericReturnType()));
+
         var apiResponse = createAPIResponse()
-                .description("OK");
+                .description("OK")
+                .content(createContent().addMediaType(APPLICATION_TYPE_JSON, mediaType));
+
 
         if ( isJsonArray(method.getReturnType()) )
         {
-            System.out.println("ARRAY!!! " + method.getName());
-            var mediaType = createMediaType();
-            mediaType.setSchema(createInternalSchema(method.getReturnType(), method.getGenericReturnType()));
-            apiResponse.content(createContent().addMediaType(APPLICATION_TYPE_JSON, mediaType));
             addComponent(extractTypeFromArray(method.getGenericReturnType()));
-        } else if ( method.getReturnType() != void.class )
-        {
-            var mediaType = createMediaType();
-            mediaType.setSchema(createInternalSchema(method.getReturnType(), method.getGenericReturnType()));
-            apiResponse.content(createContent().addMediaType(APPLICATION_TYPE_JSON, mediaType));
+        } else  {
             addComponent(method.getReturnType());
         }
 
-        return apiResponse; //If return type is void
+        return apiResponse;
     }
 
     public String getOpenAPI() {

--- a/jexxa-web/src/main/java/io/jexxa/infrastructure/drivingadapter/rest/openapi/OpenAPIConvention.java
+++ b/jexxa-web/src/main/java/io/jexxa/infrastructure/drivingadapter/rest/openapi/OpenAPIConvention.java
@@ -1,11 +1,13 @@
 package io.jexxa.infrastructure.drivingadapter.rest.openapi;
 
 
+import io.smallrye.openapi.api.models.parameters.RequestBodyImpl;
 import io.smallrye.openapi.runtime.io.Format;
 import io.smallrye.openapi.runtime.io.OpenApiSerializer;
 import org.eclipse.microprofile.openapi.models.Components;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.eclipse.microprofile.openapi.models.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.models.responses.APIResponse;
 
 import java.io.IOException;
@@ -17,6 +19,7 @@ import java.net.HttpURLConnection;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Properties;
@@ -71,19 +74,21 @@ public class OpenAPIConvention
         {
             return;
         }
+        var operation = createOperation()
+                .operationId(method.getName())
+                .responses(
+                        createAPIResponses()
+                                .addAPIResponse(String.valueOf(HttpURLConnection.HTTP_OK), documentReturnType(method))
+                                .addAPIResponse(String.valueOf(HttpURLConnection.HTTP_BAD_REQUEST), documentException())
+                );
+
+        createRequestBody(method).ifPresent(operation::requestBody);
+
         openAPI.getPaths().addPathItem(
-            resourcePath, createPathItem()
-                        .GET(createOperation()
-                                .operationId(method.getName())
-                                .responses(
-                                        createAPIResponses()
-                                                .addAPIResponse(String.valueOf(HttpURLConnection.HTTP_OK), documentReturnType(method))
-                                                .addAPIResponse(String.valueOf(HttpURLConnection.HTTP_BAD_REQUEST), documentException())
-                                        //TODO: Add Parameters
-                                    )
-                    )
+            resourcePath, createPathItem().GET(operation)
         );
     }
+
 
     public void documentPOST(Method method, String resourcePath)
     {
@@ -91,19 +96,54 @@ public class OpenAPIConvention
         {
             return;
         }
+        var operation = createOperation()
+                .operationId(method.getName())
+                .responses(
+                        createAPIResponses()
+                                .addAPIResponse(String.valueOf(HttpURLConnection.HTTP_OK), documentReturnType(method))
+                                .addAPIResponse(String.valueOf(HttpURLConnection.HTTP_BAD_REQUEST), documentException())
+                );
+
+
+        createRequestBody(method).ifPresent(operation::requestBody);
 
         openAPI.getPaths().addPathItem(
-                resourcePath, createPathItem()
-                        .POST(createOperation()
-                                .operationId(method.getName())
-                                .responses(
-                                        createAPIResponses()
-                                                .addAPIResponse(String.valueOf(HttpURLConnection.HTTP_OK), documentReturnType(method))
-                                                .addAPIResponse(String.valueOf(HttpURLConnection.HTTP_BAD_REQUEST), documentException())
-                                        //TODO: Add Parameters
-                                )
-                        )
+                resourcePath, createPathItem().POST(operation)
         );
+    }
+
+    private Optional<RequestBody> createRequestBody(Method method) {
+        if (method.getParameters().length == 0)
+        {
+            return Optional.empty();
+        }
+
+        var requestBody = new RequestBodyImpl();
+
+        if (method.getParameterCount()  == 1 )
+        {
+            requestBody.setRequired(true);
+            var mediaType = createMediaType().schema(createInternalSchema(method.getParameterTypes()[0], method.getGenericParameterTypes()[0]));
+            mediaType.setExample(createExample(method.getParameterTypes()[0], method.getGenericParameterTypes()[0]));
+            requestBody.content(createContent().addMediaType(APPLICATION_TYPE_JSON, mediaType));
+            addComponent(method.getParameterTypes()[0]);
+
+        }  else if ( method.getParameterCount() > 1 )
+        {
+            requestBody.setRequired(true);
+            var schema = createSchema();
+            var example = new ArrayList<>(method.getParameterCount());
+            for (var i = 0; i < method.getParameterTypes().length; ++i)
+            {
+                schema.addAnyOf(createInternalSchema(method.getParameterTypes()[i], method.getGenericParameterTypes()[i]));
+                example.add( createExample(method.getParameterTypes()[i], method.getGenericParameterTypes()[i]));
+                addComponent(method.getParameterTypes()[i]);
+            }
+            var mediaType = createMediaType().schema(schema);
+            mediaType.setExample(example);
+            requestBody.content(createContent().addMediaType(APPLICATION_TYPE_JSON, mediaType));
+        }
+        return Optional.of(requestBody);
     }
 
     private APIResponse documentException()
@@ -163,169 +203,6 @@ public class OpenAPIConvention
         }
         return Optional.empty();
     }
-
-
-  /*  private static final String APPLICATION_TYPE_JSON = "application/json";
-    private static final String JSON_OBJECT_TYPE = "object";
-    private static final String JSON_ARRAY_TYPE = "array";
-
-    private final Properties properties;
-    private final JavalinConfig javalinConfig;
-    private OpenApiOptions openApiOptions;
-
-    public OpenAPIConvention(Properties properties, JavalinConfig javalinConfig)
-    {
-        this.properties = properties;
-        this.javalinConfig = javalinConfig;
-
-        initOpenAPI();
-    }
-    private void initOpenAPI()
-    {
-        if (properties.containsKey(JEXXA_REST_OPEN_API_PATH))
-        {
-            OpenApiVersionUtil.INSTANCE.setLogWarnings(false);
-
-            var applicationInfo = new Info()
-                    .version(properties.getProperty(JEXXA_CONTEXT_VERSION, "1.0"))
-                    .description("Auto generated OpenAPI for " + properties.getProperty(JEXXA_CONTEXT_NAME, "Unknown Context"))
-                    .title(properties.getProperty(JEXXA_CONTEXT_NAME, "Unknown Context"));
-
-            openApiOptions = new OpenApiOptions(applicationInfo)
-                    .path("/" + properties.getProperty(JEXXA_REST_OPEN_API_PATH));
-
-            //Show all fields of an ValueObject
-            openApiOptions.getJacksonMapper().setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
-
-            javalinConfig.registerPlugin(new OpenApiPlugin(openApiOptions));
-            javalinConfig.enableCorsForAllOrigins();
-
-            openApiOptions.defaultDocumentation(doc -> {
-                doc.json(String.valueOf(HTTP_BAD_REQUEST), BadRequestResponse.class);
-                doc.json(String.valueOf(HTTP_BAD_REQUEST), BadRequestResponse.class);
-            });
-        }
-    }
-
-    boolean isEnabled()
-    {
-        return openApiOptions != null;
-    }
-
-    public Optional<String> getPath()
-    {
-        if (isEnabled()) {
-            return Optional.of("/" + properties.getProperty(JEXXA_REST_OPEN_API_PATH));
-        }
-
-        return Optional.empty();
-    }
-
-    public void documentGET(Method method, String resourcePath)
-    {
-        if ( openApiOptions == null )
-        {
-            return;
-        }
-
-        var openApiDocumentation = OpenApiBuilder
-                .document()
-                .operation(openApiOperation -> {
-                    openApiOperation.operationId(method.getName());
-                });
-
-        documentReturnType(method, openApiDocumentation);
-
-        openApiOptions.setDocumentation(resourcePath, HttpMethod.GET, openApiDocumentation);
-    }
-
-    public void documentPOST(Method method, String resourcePath)
-    {
-        if ( openApiOptions == null )
-        {
-            return;
-        }
-
-        var openApiDocumentation = OpenApiBuilder
-                .document()
-                .operation(openApiOperation -> {
-                    openApiOperation.operationId(method.getName());
-                });
-
-        documentParameters(method, openApiDocumentation);
-
-        documentReturnType(method, openApiDocumentation);
-
-        openApiOptions.setDocumentation(resourcePath, HttpMethod.POST, openApiDocumentation);
-    }
-
-    private static void documentReturnType(Method method, OpenApiDocumentation openApiDocumentation)
-    {
-        if ( isJsonArray(method.getReturnType()) )
-        {
-            openApiDocumentation.jsonArray("200", extractTypeFromArray(method.getGenericReturnType()));
-        } else if ( method.getReturnType() != void.class )
-        {
-            openApiDocumentation.json("200", method.getReturnType());
-        }
-        else {
-            openApiDocumentation.result("200");
-        }
-    }
-
-    private static void documentParameters(Method method, OpenApiDocumentation openApiDocumentation)
-    {
-        if (method.getParameters().length == 1 )
-        {
-            var schema = createSchema(method.getParameterTypes()[0], method.getGenericParameterTypes()[0]);
-            schema.setExample(createExampleInstance(method.getParameterTypes()[0], method.getGenericParameterTypes()[0]));
-
-            //For some reason I have to add requests as DocumentedContent. Otherwise, components seems to be not correctly created
-            openApiDocumentation.body(List.of(new DocumentedContent(method.getParameterTypes()[0], isJsonArray(method.getParameterTypes()[0]), APPLICATION_TYPE_JSON )));
-            openApiDocumentation.body(schema, APPLICATION_TYPE_JSON);
-        }  else if ( method.getParameters().length > 1 )
-        {
-            var schema = new ComposedSchema();
-            var exampleObjects = new Object[method.getParameterTypes().length];
-            var documentedContend = new ArrayList<DocumentedContent>();
-
-            for (var i = 0; i < method.getParameterTypes().length; ++i)
-            {
-                exampleObjects[i] = createExampleInstance(method.getParameterTypes()[i],method.getGenericParameterTypes()[i]);
-                var parameterSchema = createSchema(method.getParameterTypes()[i], method.getGenericParameterTypes()[i]);
-                parameterSchema.setExample(exampleObjects[i]);
-
-                documentedContend.add( new DocumentedContent(method.getParameterTypes()[i], isJsonArray(method.getParameterTypes()[i]), APPLICATION_TYPE_JSON ));
-                schema.addAnyOfItem(parameterSchema);
-            }
-
-            schema.setExample(exampleObjects);
-            //For some reason I have to add requests as DocumentedContent. Otherwise, components seems to be not correctly created
-            openApiDocumentation.body(documentedContend);
-            openApiDocumentation.body(schema, APPLICATION_TYPE_JSON);
-        }
-    }*/
-
-    /*private static String createJsonSchema(Class<?> clazz) throws JsonProcessingException
-    {
-        var mapper = new ObjectMapper();
-        mapper.registerModule(new JavaTimeModule());
-        mapper.registerModule(new Jdk8Module());
-
-
-        //There are other configuration options you can set.  This is the one I needed.
-        mapper.configure(WRITE_ENUMS_USING_TO_STRING, true);
-        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        // StdDateFormat is ISO8601 since jackson 2.9
-        mapper.setDateFormat(new StdDateFormat().withColonInTimeZone(true));
-        mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
-
-        var jsonSchemaGenerator = new JsonSchemaGenerator(mapper);
-        var jsonSchema = jsonSchemaGenerator.generateJsonSchema(clazz);
-
-        return mapper.writeValueAsString(jsonSchema);
-    }*/
-
 
     private static Schema createInternalSchema(Class<?> clazz, Type genericType)
     {
@@ -387,50 +264,78 @@ public class OpenAPIConvention
     }
 
     private Schema createComponentSchema(Class<?> clazz, Type genericType)
+    {
+        var schema = createSchema();
+
+        if ( isInteger(clazz) )
         {
-            var schema = createSchema();
-
-            if ( isInteger(clazz) )
-            {
-                schema.setType(Schema.SchemaType.INTEGER);
-                return schema;
-            }
-
-            if ( isNumber(clazz) )
-            {
-                schema.setType(Schema.SchemaType.NUMBER);
-                return schema;
-            }
-
-            if ( isBoolean(clazz) )
-            {
-                schema.setType(Schema.SchemaType.BOOLEAN);
-                return schema;
-            }
-
-            if ( isString(clazz) || isJava8Date(clazz))
-            {
-                schema.setType(Schema.SchemaType.STRING);
-                return schema;
-            }
-
-            if ( isJsonArray(clazz) )
-            {
-                schema.setType(Schema.SchemaType.ARRAY);
-                //TODO: schema.setRef(extractTypeFromArray(genericType).getSimpleName());
-                // TODO Handle arrays
-                return schema;
-            }
-
-            schema.setType(Schema.SchemaType.OBJECT);
-            Stream.of(clazz.getDeclaredFields())
-                .filter(element -> !Modifier.isStatic(element.getModifiers()))
-                .forEach(element -> schema.addProperty(element.getName(), createComponentSchema(element.getType(), element.getGenericType())));
-
+            schema.setType(Schema.SchemaType.INTEGER);
             return schema;
         }
 
+        if ( isNumber(clazz) )
+        {
+            schema.setType(Schema.SchemaType.NUMBER);
+            return schema;
+        }
 
+        if ( isBoolean(clazz) )
+        {
+            schema.setType(Schema.SchemaType.BOOLEAN);
+            return schema;
+        }
+
+        if ( isString(clazz) || isJava8Date(clazz))
+        {
+            schema.setType(Schema.SchemaType.STRING);
+            return schema;
+        }
+
+        if ( isJsonArray(clazz) )
+        {
+            schema.setType(Schema.SchemaType.ARRAY);
+            // TODO Handle arrays
+            return schema;
+        }
+
+        schema.setType(Schema.SchemaType.OBJECT);
+        Stream.of(clazz.getDeclaredFields())
+            .filter(element -> !Modifier.isStatic(element.getModifiers()))
+            .forEach(element -> schema.addProperty(element.getName(), createComponentSchema(element.getType(), element.getGenericType())));
+
+        return schema;
+    }
+
+    private Object createExample(Class<?> clazz, Type genericType)
+    {
+        if ( isInteger(clazz) || isNumber(clazz))
+        {
+            return 0;
+        }
+
+        if ( isBoolean(clazz) )
+        {
+            return true;
+        }
+
+        if ( isString(clazz))
+        {
+            return "";
+        }
+        if ( isJava8Date(clazz))
+        {
+            return "2022-11-13T06:08:41Z";
+        }
+
+        if ( isJsonArray(clazz) )
+        {
+            var returnValue = new Object[1];
+            returnValue[0]= createExample(extractTypeFromArray(genericType), genericType);
+            return returnValue;
+        }
+
+        return null;
+    }
     private static boolean isInteger(Class<?> clazz)
     {
         return clazz.equals(Short.class) ||

--- a/jexxa-web/src/main/java/io/jexxa/infrastructure/drivingadapter/rest/openapi/OpenAPIConvention.java
+++ b/jexxa-web/src/main/java/io/jexxa/infrastructure/drivingadapter/rest/openapi/OpenAPIConvention.java
@@ -13,6 +13,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.net.HttpURLConnection;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
@@ -76,10 +77,8 @@ public class OpenAPIConvention
                                 .operationId(method.getName())
                                 .responses(
                                         createAPIResponses()
-                                                .addAPIResponse(
-                                                        "200", documentReturnType(method)
-                                                    )
-                                        //TODO: Add BadRequest
+                                                .addAPIResponse(String.valueOf(HttpURLConnection.HTTP_OK), documentReturnType(method))
+                                                .addAPIResponse(String.valueOf(HttpURLConnection.HTTP_BAD_REQUEST), documentException())
                                         //TODO: Add Parameters
                                     )
                     )
@@ -99,13 +98,26 @@ public class OpenAPIConvention
                                 .operationId(method.getName())
                                 .responses(
                                         createAPIResponses()
-                                                .addAPIResponse("200", documentReturnType(method))
-                                        //TODO: Add BadRequest
+                                                .addAPIResponse(String.valueOf(HttpURLConnection.HTTP_OK), documentReturnType(method))
+                                                .addAPIResponse(String.valueOf(HttpURLConnection.HTTP_BAD_REQUEST), documentException())
                                         //TODO: Add Parameters
                                 )
                         )
         );
     }
+
+    private APIResponse documentException()
+    {
+        addComponent(BadRequestResponse.class);
+
+        var mediaType = createMediaType()
+                .schema(createInternalSchema(BadRequestResponse.class, BadRequestResponse.class));
+
+        return createAPIResponse()
+                .description("BAD REQUEST")
+                .content(createContent().addMediaType(APPLICATION_TYPE_JSON, mediaType));
+    }
+
     public boolean isDisabled()
     {
         return getPath().isEmpty();

--- a/jexxa-web/src/main/java/io/jexxa/infrastructure/drivingadapter/rest/openapi/OpenAPIConvention.java
+++ b/jexxa-web/src/main/java/io/jexxa/infrastructure/drivingadapter/rest/openapi/OpenAPIConvention.java
@@ -316,7 +316,6 @@ public class OpenAPIConvention
     private static Schema createInternalSchema(Class<?> clazz, Type genericType)
     {
         var schema = createSchema();
-        schema.setFormat(APPLICATION_TYPE_JSON);
 
         if ( isInteger(clazz) )
         {
@@ -376,7 +375,6 @@ public class OpenAPIConvention
     private Schema createComponentSchema(Class<?> clazz, Type genericType)
         {
             var schema = createSchema();
-            schema.setFormat(APPLICATION_TYPE_JSON);
 
             if ( isInteger(clazz) )
             {

--- a/jexxa-web/src/main/java/io/jexxa/infrastructure/drivingadapter/rest/openapi/OpenAPIConvention.java
+++ b/jexxa-web/src/main/java/io/jexxa/infrastructure/drivingadapter/rest/openapi/OpenAPIConvention.java
@@ -1,9 +1,91 @@
 package io.jexxa.infrastructure.drivingadapter.rest.openapi;
 
 
+import io.smallrye.openapi.runtime.io.Format;
+import io.smallrye.openapi.runtime.io.OpenApiSerializer;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+
+import static org.eclipse.microprofile.openapi.OASFactory.createAPIResponse;
+import static org.eclipse.microprofile.openapi.OASFactory.createAPIResponses;
+import static org.eclipse.microprofile.openapi.OASFactory.createInfo;
+import static org.eclipse.microprofile.openapi.OASFactory.createOpenAPI;
+import static org.eclipse.microprofile.openapi.OASFactory.createOperation;
+import static org.eclipse.microprofile.openapi.OASFactory.createPathItem;
+import static org.eclipse.microprofile.openapi.OASFactory.createPaths;
+import static org.eclipse.microprofile.openapi.OASFactory.createServer;
+
 @SuppressWarnings("java:S1602") // required to avoid ambiguous warnings
 public class OpenAPIConvention
 {
+    private final OpenAPI openAPI;
+
+    public OpenAPIConvention()
+    {
+        openAPI = createOpenAPI()
+                .openapi("3.0.1")
+                .info(
+                        createInfo()
+                                .title("Ping Specification")
+                                .version("1.0")
+                )
+                .addServer(
+                        createServer()
+                                .url("http://localhost:8080/")
+                )
+                .paths(
+                        createPaths()
+                );
+    }
+    public void documentGET(Method method, String resourcePath)
+    {
+        openAPI.getPaths().addPathItem(
+            resourcePath, createPathItem()
+                        .GET(createOperation()
+                                .operationId(method.getName())
+                                .responses(
+                                        createAPIResponses()
+                                                .addAPIResponse(
+                                                        "200", createAPIResponse()
+                                                                .description("OK")
+                                                    )
+                                    )
+                    )
+        );
+    }
+
+    public void documentPOST(Method method, String resourcePath)
+    {
+        openAPI.getPaths().addPathItem(
+                resourcePath, createPathItem()
+                        .POST(createOperation()
+                                .operationId(method.getName())
+                                .responses(
+                                        createAPIResponses()
+                                                .addAPIResponse(
+                                                        "200", createAPIResponse()
+                                                                .description("OK")
+                                                )
+                                )
+                        )
+        );
+
+    }
+
+    public void showInfo() {
+        String content;
+        try {
+            content = OpenApiSerializer.serialize(openAPI, Format.YAML);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        System.out.println(content);
+    }
+
+
+
   /*  private static final String APPLICATION_TYPE_JSON = "application/json";
     private static final String JSON_OBJECT_TYPE = "object";
     private static final String JSON_ARRAY_TYPE = "array";

--- a/jexxa-web/src/test/java/io/jexxa/infrastructure/drivingadapter/rest/OpenAPIIT.java
+++ b/jexxa-web/src/test/java/io/jexxa/infrastructure/drivingadapter/rest/OpenAPIIT.java
@@ -9,6 +9,7 @@ import io.jexxa.application.domain.model.SpecialCasesValueObject;
 import kong.unirest.Unirest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -68,6 +69,7 @@ class OpenAPIIT
 
     @ParameterizedTest
     @MethodSource("applicationServiceConfig")
+    @Disabled
     void testBasicStructure(Object applicationService)
     {
         //Arrange
@@ -89,6 +91,7 @@ class OpenAPIIT
 
 
     @Test
+    @Disabled
     void testSpecialCasesValueObject()
     {
         //Arrange -> Nothing to do
@@ -114,6 +117,7 @@ class OpenAPIIT
 
     @ParameterizedTest
     @MethodSource("applicationServiceConfig")
+    @Disabled
     void testContentTypeIsJson(Object applicationService)
     {
         //Arrange
@@ -134,6 +138,7 @@ class OpenAPIIT
 
     @ParameterizedTest
     @MethodSource("applicationServiceConfig")
+    @Disabled
     void testHTTPRequestMapping(Object applicationService)
     {
         //Arrange

--- a/jexxa-web/src/test/java/io/jexxa/infrastructure/drivingadapter/rest/OpenAPIIT.java
+++ b/jexxa-web/src/test/java/io/jexxa/infrastructure/drivingadapter/rest/OpenAPIIT.java
@@ -9,7 +9,6 @@ import io.jexxa.application.domain.model.SpecialCasesValueObject;
 import kong.unirest.Unirest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -69,7 +68,6 @@ class OpenAPIIT
 
     @ParameterizedTest
     @MethodSource("applicationServiceConfig")
-    @Disabled
     void testBasicStructure(Object applicationService)
     {
         //Arrange
@@ -91,7 +89,6 @@ class OpenAPIIT
 
 
     @Test
-    @Disabled
     void testSpecialCasesValueObject()
     {
         //Arrange -> Nothing to do
@@ -117,7 +114,6 @@ class OpenAPIIT
 
     @ParameterizedTest
     @MethodSource("applicationServiceConfig")
-    @Disabled
     void testContentTypeIsJson(Object applicationService)
     {
         //Arrange
@@ -138,7 +134,6 @@ class OpenAPIIT
 
     @ParameterizedTest
     @MethodSource("applicationServiceConfig")
-    @Disabled
     void testHTTPRequestMapping(Object applicationService)
     {
         //Arrange

--- a/jexxa-web/src/test/resources/jexxa-application.properties
+++ b/jexxa-web/src/test/resources/jexxa-application.properties
@@ -1,6 +1,11 @@
 #suppress inspection "UnusedProperty" for whole file
 
 ##########################################
+# Adjust system properties               #
+##########################################
+io.jexxa.user.timezone="UTC"
+
+##########################################
 #Settings for JMSAdapter and JMSSender   #
 ##########################################
 java.naming.factory.initial=org.apache.activemq.jndi.ActiveMQInitialContextFactory

--- a/jexxa-web/src/test/resources/jexxa-application.properties
+++ b/jexxa-web/src/test/resources/jexxa-application.properties
@@ -3,7 +3,7 @@
 ##########################################
 # Adjust system properties               #
 ##########################################
-io.jexxa.user.timezone="UTC"
+#io.jexxa.user.timezone=UTC
 
 ##########################################
 #Settings for JMSAdapter and JMSSender   #

--- a/jexxa-web/src/test/resources/simplelogger.properties
+++ b/jexxa-web/src/test/resources/simplelogger.properties
@@ -1,0 +1,35 @@
+# SLF4J's SimpleLogger configuration file
+# Simple implementation of Logger that sends all enabled log messages, for all defined loggers, to System.err.
+# Default logging detail level for all instances of SimpleLogger.
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, defaults to "info".
+org.slf4j.simpleLogger.defaultLogLevel=info
+
+# Logging detail level for a SimpleLogger instance named "xxxxx".
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, the default logging detail level is used.
+#org.slf4j.simpleLogger.log.xxxxx=
+org.slf4j.simpleLogger.log.org.eclipse.jetty.server=warn
+org.slf4j.simpleLogger.log.io.javalin=warn
+
+# Set to true if you want the current date and time to be included in output messages.
+# Default is false, and will output the number of milliseconds elapsed since startup.
+org.slf4j.simpleLogger.showDateTime=true
+
+# The date and time format to be used in the output messages.
+# The pattern describing the date and time format is the same that is used in java.text.SimpleDateFormat.
+# If the format is not specified or is invalid, the default format is used.
+# The default format is yyyy-MM-dd HH:mm:ss:SSS Z.
+org.slf4j.simpleLogger.dateTimeFormat='['yyyy-MM-dd'T'HH:mmXXX']' 
+
+# Set to true if you want to output the current thread name.
+# Defaults to true.
+org.slf4j.simpleLogger.showThreadName=false
+
+# Set to true if you want the Logger instance name to be included in output messages.
+# Defaults to true.
+#org.slf4j.simpleLogger.showLogName=true
+
+# Set to true if you want the Logger instance short name to be included in output messages.
+# Defaults to false.
+org.slf4j.simpleLogger.showShortLogName=true

--- a/jexxa-web/src/test/resources/simplelogger.properties
+++ b/jexxa-web/src/test/resources/simplelogger.properties
@@ -1,3 +1,5 @@
+#suppress inspection "UnusedProperty" for whole file
+
 # SLF4J's SimpleLogger configuration file
 # Simple implementation of Logger that sends all enabled log messages, for all defined loggers, to System.err.
 # Default logging detail level for all instances of SimpleLogger.
@@ -20,7 +22,7 @@ org.slf4j.simpleLogger.showDateTime=true
 # The pattern describing the date and time format is the same that is used in java.text.SimpleDateFormat.
 # If the format is not specified or is invalid, the default format is used.
 # The default format is yyyy-MM-dd HH:mm:ss:SSS Z.
-org.slf4j.simpleLogger.dateTimeFormat='['yyyy-MM-dd'T'HH:mmXXX']' 
+org.slf4j.simpleLogger.dateTimeFormat='['yyyy-MM-dd'T'HH:mmXXX']'
 
 # Set to true if you want to output the current thread name.
 # Defaults to true.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.jexxa</groupId>
   <artifactId>jexxa</artifactId>
-  <version>5.4.1-SNAPSHOT</version>
+  <version>5.5.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <!-- Project Information -->

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
 
     <!-- version of compile dependencies -->
     <classgraph.version>4.8.149</classgraph.version>
-    <javalin.version>4.6.7</javalin.version>
+    <javalin.version>5.1.3</javalin.version>
     <javax.jms.version>2.0.1</javax.jms.version>
     <slf4j.api.version>2.0.3</slf4j.api.version>
     <gson.version>2.10</gson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 
     <!--information for filtered sources  -->
     <build.timestamp>${maven.build.timestamp}</build.timestamp>
-    <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
+    <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
 
     <!-- target/compiler configuration  -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <slf4j.api.version>2.0.3</slf4j.api.version>
     <gson.version>2.10</gson.version>
     <commons.lang3.version>3.12.0</commons.lang3.version>
-    <jackson.core.version>2.14.0-rc3</jackson.core.version>
+    <jackson.core.version>2.14.0</jackson.core.version>
     <jackson.jsonschema.version>1.0.39</jackson.jsonschema.version>
 
     <!-- version of test dependencies -->


### PR DESCRIPTION
- [Issue #142](https://github.com/jexxa-projects/Jexxa/issues/140) Jexxa-Web : Updated from javalin4 to javalin5. This required to reimplement OpenAPI functionality because javalin5 no longer supports a Java-DSL to provide OpenAPI information. Even though the public API of Jexxa-Web is not changed we decided to increment minor version due to the re-implementation of OpenAPI 
